### PR TITLE
Macの[delete]キー用のキーマップ追加

### DIFF
--- a/lib/textbringer/keymap.rb
+++ b/lib/textbringer/keymap.rb
@@ -109,6 +109,7 @@ module Textbringer
   GLOBAL_MAP.define_key(?\C-d, :delete_char)
   GLOBAL_MAP.define_key(:backspace, :backward_delete_char)
   GLOBAL_MAP.define_key(?\C-h, :backward_delete_char)
+  GLOBAL_MAP.define_key(?\C-?, :backward_delete_char)
   GLOBAL_MAP.define_key(?\C-a, :beginning_of_line)
   GLOBAL_MAP.define_key(:home, :beginning_of_line)
   GLOBAL_MAP.define_key(?\C-e, :end_of_line)


### PR DESCRIPTION
日本語で失礼いたします。

macOSでTextbringerを遊び始めていますが、deleteキーが効きませんでした。

macOS sierra
ruby：2.4.0p0
curses：1.2.1
ターミナル：ターミナル（macOS標準）、iTerm2

deleteキーのコードはCTRL + ?の様なので、キーマップを追加してみました。
ご査収をお願いいたします。

// Ruby製テキストエディタに大きな可能性を感じております。