### PR TITLE
Show dirname in find_file prompt

### DIFF
--- a/lib/textbringer/commands/files.rb
+++ b/lib/textbringer/commands/files.rb
@@ -3,7 +3,7 @@ require "editorconfig"
 module Textbringer
   module Commands
     define_command(:find_file, doc: "Open or create a file.") do
-      |file_name = read_file_name("Find file: ")|
+      |file_name = read_file_name("Find file: ", default: (Buffer.current.file_name ? File.dirname(Buffer.current.file_name) : Dir.pwd) + "/")|
       config = EditorConfig.load_file(file_name)
       buffer = Buffer.find_file(file_name)
       if buffer.new_file?


### PR DESCRIPTION
Show dirname of current buffer in find_file prompt.
If you did not open any files, show pwd.