### PR TITLE
Simplify `.b` call

### DIFF
--- a/test/textbringer/test_buffer.rb
+++ b/test/textbringer/test_buffer.rb
@@ -1764,8 +1764,8 @@ EOF
     end
     buffer.beginning_of_buffer
     buffer.forward_char(0xe3)
-    assert_equal((+"\xe3").b, buffer.byte_after)
-    assert_equal((+"\xe3").b, buffer.char_after)
+    assert_equal("\xe3".b, buffer.byte_after)
+    assert_equal("\xe3".b, buffer.char_after)
     buffer = Buffer.new(data, file_encoding: "ascii-8bit")
     assert_equal(true, buffer.binary?)
   end


### PR DESCRIPTION
`.b` returns another string, so there is no need for the receiver to be mutable.