### PR TITLE
Revert "Use `# frozen-string-literal: false` to suppress warnings"

### DIFF
--- a/test/textbringer/test_buffer.rb
+++ b/test/textbringer/test_buffer.rb
@@ -1,5 +1,3 @@
-# frozen-string-literal: false
-
 require_relative "../test_helper"
 require "tempfile"
 require "tmpdir"


### PR DESCRIPTION
This reverts commit 65c4050b478f886feb877ab177b871462dc37c0b.

As far as I can tell, this isn't needed, the test suite passes without any warning.