### PR TITLE
Display combining marks

### DIFF
--- a/lib/textbringer/buffer.rb
+++ b/lib/textbringer/buffer.rb
@@ -822,6 +822,10 @@ module Textbringer
       @point > mark.location
     end
 
+    def point_compare_mark(mark)
+      @point - mark.location
+    end
+
     def exchange_point_and_mark(mark = @mark)
       if mark.nil?
         raise EditorError, "The mark is not set"

--- a/test/textbringer/test_window.rb
+++ b/test/textbringer/test_window.rb
@@ -210,6 +210,18 @@ end
 EOF
   end
 
+  def test_redisplay_combining_marks
+    @buffer.insert(<<'EOF')
+アパート
+修正すべきファイル
+EOF
+    @window.redisplay
+    assert_equal(<<'EOF' + "\n" * 20, window_string(@window.window))
+アパート
+修正すべきファイル
+EOF
+  end
+
   def test_s_current
     window = Window.current
     window.split


### PR DESCRIPTION
There was a bug that `アパート` is displayed as `アハート`, where `パ` is composed of U+30CF and U+309A.

* [ ] echo areaの修正