### PR TITLE
Use pull_request close events to tag version

### DIFF
--- a/.github/workflows/tag_version.yml
+++ b/.github/workflows/tag_version.yml
@@ -1,17 +1,15 @@
 name: Tag version
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'lib/textbringer/version.rb'
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
 
 jobs:
   tag_version:
+    if: ${{ github.repository == 'shugo/textbringer' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && startsWith(github.event.pull_request.head.ref, 'bump_version_to_v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Because push events don't trigger workflows when the commit is created by another workflow using GITHUB_TOKEN.