### PR TITLE
Calculate rectangle boundaries with multibyte characters properly

### DIFF
--- a/test/textbringer/commands/test_buffers.rb
+++ b/test/textbringer/commands/test_buffers.rb
@@ -469,4 +469,19 @@ EOF
     expected = "XXDEFXXX\nYY   YYY\nZZDEFZZZ"
     assert_equal(expected, buffer.to_s)
   end
+
+  def test_rectangle_multibyte
+    buffer = Buffer.current
+    insert(<<~EOF)
+      あいうえお
+      かきくけこ
+    EOF
+    beginning_of_buffer
+    forward_char
+    set_mark_command
+    next_line
+    forward_char(3)
+    lines = buffer.extract_rectangle
+    assert_equal(["いうえ", "きくけ"], lines)
+  end
 end


### PR DESCRIPTION
Buffer#get_line_and_column returns codepoint-based column, so it's not appropriate to display width calculation.