### PR TITLE
feat: Add string_insert_rectangle command

### DIFF
--- a/lib/textbringer/commands/rectangle.rb
+++ b/lib/textbringer/commands/rectangle.rb
@@ -210,6 +210,17 @@ module Textbringer::Buffer::RectangleMethods
       end
     end
 
+    def string_insert_rectangle(str, s = @point, e = mark)
+      check_read_only_flag
+      apply_on_rectangle(s, e) do |start_col, end_col, col, line_start|
+        start_pos = @point
+        if col < start_col
+          insert(" " * (start_col - col))
+        end
+        insert(str)
+      end
+    end
+
     def rectangle_number_lines(s = @point, e = mark)
       check_read_only_flag
       n = 1
@@ -264,6 +275,12 @@ module Textbringer
                    doc: "Replace rectangle contents with the specified string on each line.") do
       |str = read_from_minibuffer("String rectangle: ")|
       Buffer.current.string_rectangle(str)
+    end
+
+    define_command(:string_insert_rectangle,
+                   doc: "Insert the specified string on each line of the rectangle.") do
+      |str = read_from_minibuffer("String insert rectangle: ")|
+      Buffer.current.string_insert_rectangle(str)
     end
 
     define_command(:rectangle_number_lines,

--- a/test/textbringer/commands/test_rectangle.rb
+++ b/test/textbringer/commands/test_rectangle.rb
@@ -274,6 +274,50 @@ baz
     EOF
   end
 
+  def test_string_insert_rectangle
+    insert(<<-EOF)
+foo
+bar
+baz
+quux
+    EOF
+    beginning_of_buffer
+    forward_char
+    set_mark_command
+    next_line(2)
+    forward_char
+    push_keys("inserted\n")
+    string_insert_rectangle
+    assert_equal(<<-EOF, Buffer.current.to_s)
+finsertedoo
+binsertedar
+binsertedaz
+quux
+    EOF
+
+    Buffer.current.clear
+    insert(<<-EOF)
+foo
+
+bar
+baz
+    EOF
+
+    beginning_of_buffer
+    forward_char
+    set_mark_command
+    next_line(2)
+    forward_char
+    push_keys("X\n")
+    string_insert_rectangle
+    assert_equal(<<-EOF, Buffer.current.to_s)
+fXoo
+ X
+bXar
+baz
+    EOF
+  end
+
   def test_rectangle_number_lines
     insert(<<-EOF)
  foo


### PR DESCRIPTION
Add a `string_insert_rectangle` command that is equivalent to Emacs's `string-insert-rectangle`.

This command inserts a specified string at the beginning of each line in a rectangular region.