### PR TITLE
Fix clipboard kill commands to copy to clipboard on read-only buffers

### DIFF
--- a/lib/textbringer/commands/clipboard.rb
+++ b/lib/textbringer/commands/clipboard.rb
@@ -29,23 +29,38 @@ module Textbringer
         Copy the region to the kill ring and the clipboard, and delete
         the region.
       EOD
-      kill_region
-      Clipboard.copy(KILL_RING.current)
+      begin
+        kill_region
+        Clipboard.copy(KILL_RING.current)
+      rescue ReadOnlyError
+        Clipboard.copy(KILL_RING.current)
+        raise
+      end
     end
 
     define_command(:clipboard_kill_line, doc: <<~EOD) do
         Kill the rest of the current line, and copy the killed text to
         the clipboard.
       EOD
-      kill_line
-      Clipboard.copy(KILL_RING.current)
+      begin
+        kill_line
+        Clipboard.copy(KILL_RING.current)
+      rescue ReadOnlyError
+        Clipboard.copy(KILL_RING.current)
+        raise
+      end
     end
 
     define_command(:clipboard_kill_word, doc: <<~EOD) do
         Kill a word, and copy the word to the clipboard.
       EOD
-      kill_word
-      Clipboard.copy(KILL_RING.current)
+      begin
+        kill_word
+        Clipboard.copy(KILL_RING.current)
+      rescue ReadOnlyError
+        Clipboard.copy(KILL_RING.current)
+        raise
+      end
     end
 
     define_command(:clipboard_yank, doc: <<~EOD) do

--- a/test/textbringer/commands/test_clipboard.rb
+++ b/test/textbringer/commands/test_clipboard.rb
@@ -25,6 +25,19 @@ class TestClipboard < Textbringer::TestCase
     assert_equal("かきくけこ\n", Clipboard.paste.encode("utf-8"))
   end
 
+  def test_clipboard_kill_region_read_only
+    insert("あいうえお\n")
+    set_mark_command
+    insert("かきくけこ\n")
+    Buffer.current.read_only = true
+    assert_raise(ReadOnlyError) do
+      clipboard_kill_region
+    end
+    assert_equal("あいうえお\nかきくけこ\n", Buffer.current.to_s)
+    assert_equal("かきくけこ\n", KILL_RING.current)
+    assert_equal("かきくけこ\n", Clipboard.paste.encode("utf-8"))
+  end
+
   def test_clipboard_kill_line
     insert("あいうえお\n")
     insert("かきくけこ\n")
@@ -35,12 +48,38 @@ class TestClipboard < Textbringer::TestCase
     assert_equal("あいうえお", Clipboard.paste.encode("utf-8"))
   end
 
+  def test_clipboard_kill_line_read_only
+    insert("あいうえお\n")
+    insert("かきくけこ\n")
+    beginning_of_buffer
+    Buffer.current.read_only = true
+    assert_raise(ReadOnlyError) do
+      clipboard_kill_line
+    end
+    assert_equal("あいうえお\nかきくけこ\n", Buffer.current.to_s)
+    assert_equal("あいうえお", KILL_RING.current)
+    assert_equal("あいうえお", Clipboard.paste.encode("utf-8"))
+  end
+
   def test_clipboard_kill_word
     insert("あいうえお\n")
     insert("かきくけこ\n")
     beginning_of_buffer
     clipboard_kill_word
     assert_equal("\nかきくけこ\n", Buffer.current.to_s)
+    assert_equal("あいうえお", KILL_RING.current)
+    assert_equal("あいうえお", Clipboard.paste.encode("utf-8"))
+  end
+
+  def test_clipboard_kill_word_read_only
+    insert("あいうえお\n")
+    insert("かきくけこ\n")
+    beginning_of_buffer
+    Buffer.current.read_only = true
+    assert_raise(ReadOnlyError) do
+      clipboard_kill_word
+    end
+    assert_equal("あいうえお\nかきくけこ\n", Buffer.current.to_s)
     assert_equal("あいうえお", KILL_RING.current)
     assert_equal("あいうえお", Clipboard.paste.encode("utf-8"))
   end


### PR DESCRIPTION
When clipboard_kill_region, clipboard_kill_line, or clipboard_kill_word is executed on a read-only buffer, the text is now copied to the clipboard before the ReadOnlyError is raised. Previously, the exception prevented Clipboard.copy from being called even though kill_region had already copied the text to KILL_RING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)