### PR TITLE
Add LSP signature help command (textDocument/signatureHelp)

### DIFF
--- a/lib/textbringer/commands/lsp.rb
+++ b/lib/textbringer/commands/lsp.rb
@@ -279,7 +279,7 @@ module Textbringer
       # Close any existing signature window
       lsp_close_signature_window
 
-      columns = [label.length + 2, Curses.cols - 2].min
+      columns = [[Buffer.display_width(label) + 2, Curses.cols - 2].min, 1].max
       win = FloatingWindow.at_cursor(
         lines: 1,
         columns: columns

--- a/lib/textbringer/lsp/client.rb
+++ b/lib/textbringer/lsp/client.rb
@@ -261,7 +261,8 @@ module Textbringer
                 parameterInformation: {
                   labelOffsetSupport: true
                 }
-              }
+              },
+              contextSupport: true
             },
             synchronization: {
               didSave: true,

--- a/test/textbringer/lsp/test_client.rb
+++ b/test/textbringer/lsp/test_client.rb
@@ -107,6 +107,7 @@ class TestLSPClient < Textbringer::TestCase
     assert_equal(["plaintext"],
                  sig_help[:signatureInformation][:documentationFormat])
     assert(sig_help[:signatureInformation][:parameterInformation][:labelOffsetSupport])
+    assert(sig_help[:contextSupport])
   end
 
   def test_server_capabilities_initially_empty


### PR DESCRIPTION
Display function/method signatures in a floating window when the cursor is inside a call expression. The signature window is automatically dismissed on the next command via pre_command_hook.

- Add signatureHelp client capability and signature_help request method
- Add lsp_signature_help command with F1 s keybinding
- Check server capabilities and send proper trigger context
- Use LSP_STATUS constant for shared state across hook callbacks