### PR TITLE
Add workspace_folders parameter to LSP::Client

### DIFF
--- a/lib/textbringer/lsp/client.rb
+++ b/lib/textbringer/lsp/client.rb
@@ -10,12 +10,12 @@ module Textbringer
 
       attr_reader :root_path, :server_name, :server_capabilities
 
-      def initialize(command:, args: [], root_path:, server_name: nil, workspace_folders: [Dir.pwd])
+      def initialize(command:, args: [], root_path:, server_name: nil, workspace_folders: nil)
         @command = command
         @args = args
         @root_path = root_path
         @server_name = server_name || command
-        @workspace_folders = workspace_folders
+        @workspace_folders = Array(workspace_folders || @root_path)
         @stdin = nil
         @stdout = nil
         @stderr = nil
@@ -457,6 +457,11 @@ module Textbringer
         when "client/registerCapability"
           # Accept capability registration
           send_response(id, nil, nil)
+        when "workspace/workspaceFolders"
+          folders = @workspace_folders.map { |path|
+            { uri: "file://#{path}", name: File.basename(path) }
+          }
+          send_response(id, folders, nil)
         else
           # Unknown request - respond with method not found
           send_response(id, nil, {

--- a/lib/textbringer/lsp/server_registry.rb
+++ b/lib/textbringer/lsp/server_registry.rb
@@ -74,8 +74,7 @@ module Textbringer
               command: config.command,
               args: config.args,
               root_path: root_path,
-              server_name: config.language_id,
-              workspace_folders: [root_path]
+              server_name: config.language_id
             )
             client.start
             client

--- a/test/textbringer/lsp/test_client.rb
+++ b/test/textbringer/lsp/test_client.rb
@@ -115,6 +115,19 @@ class TestLSPClient < Textbringer::TestCase
     assert_equal({}, client.server_capabilities)
   end
 
+  def test_workspace_folders_defaults_to_root_path
+    client = LSP::Client.new(command: "ruby", args: [], root_path: "/tmp/myproject")
+    assert_equal(["/tmp/myproject"], client.instance_variable_get(:@workspace_folders))
+  end
+
+  def test_workspace_folders_explicit
+    client = LSP::Client.new(
+      command: "ruby", args: [], root_path: "/tmp/root",
+      workspace_folders: ["/tmp/a", "/tmp/b"]
+    )
+    assert_equal(["/tmp/a", "/tmp/b"], client.instance_variable_get(:@workspace_folders))
+  end
+
   def test_running_state_initially_false
     client = create_client
     refute(client.running?)


### PR DESCRIPTION
Send workspaceFolders in the LSP initialize request so servers can index the correct project root. The server registry passes [root_path], and the parameter defaults to [Dir.pwd] for direct Client usage.

Also advertise workspace.workspaceFolders: true in client capabilities.