### PR TITLE
Send CompletionContext so servers return trigger-character completions

### DIFF
--- a/lib/textbringer/commands/lsp.rb
+++ b/lib/textbringer/commands/lsp.rb
@@ -49,11 +49,7 @@ module Textbringer
         buffer.goto_char(start_point)
         buffer.point > 0 ? (buffer.backward_char; buffer.char_after) : nil
       }
-      context = if prefix.empty? && trigger_chars.include?(char_before_start)
-                  { triggerKind: 2, triggerCharacter: char_before_start }
-                else
-                  { triggerKind: 1 }
-                end
+      context = lsp_completion_context(prefix, trigger_chars, char_before_start)
 
       # Request completion
       client.completion(uri: uri, line: line, character: character, context: context) do |items, error|
@@ -185,6 +181,15 @@ module Textbringer
     end
 
     # Helper methods
+
+    def lsp_completion_context(prefix, trigger_chars, char_before_start)
+      if prefix.empty? && trigger_chars.include?(char_before_start)
+        { triggerKind: 2, # TriggerCharacter
+          triggerCharacter: char_before_start }
+      else
+        { triggerKind: 1 } # Invoked
+      end
+    end
 
     # Convert a string's character length to UTF-16 code unit count.
     # LSP positions use UTF-16 offsets by default.

--- a/lib/textbringer/lsp/client.rb
+++ b/lib/textbringer/lsp/client.rb
@@ -256,7 +256,8 @@ module Textbringer
               },
               completionItemKind: {
                 valueSet: (1..25).to_a
-              }
+              },
+              contextSupport: true
             },
             signatureHelp: {
               signatureInformation: {

--- a/test/textbringer/commands/test_lsp.rb
+++ b/test/textbringer/commands/test_lsp.rb
@@ -1,0 +1,39 @@
+require_relative "../../test_helper"
+
+class TestLSPCommands < Textbringer::TestCase
+  def test_lsp_completion_context_invoked_with_prefix
+    # When there is a prefix typed, always use Invoked (triggerKind 1)
+    context = lsp_completion_context("fo", ["."], ".")
+    assert_equal({ triggerKind: 1 }, context)
+  end
+
+  def test_lsp_completion_context_invoked_no_trigger_char
+    # Empty prefix but char before start is not a trigger character
+    context = lsp_completion_context("", ["."], "x")
+    assert_equal({ triggerKind: 1 }, context)
+  end
+
+  def test_lsp_completion_context_invoked_no_trigger_chars_configured
+    # No trigger characters configured on the server
+    context = lsp_completion_context("", [], ".")
+    assert_equal({ triggerKind: 1 }, context)
+  end
+
+  def test_lsp_completion_context_trigger_character
+    # Empty prefix and char before start is a trigger character → TriggerCharacter (triggerKind 2)
+    context = lsp_completion_context("", ["."], ".")
+    assert_equal({ triggerKind: 2, triggerCharacter: "." }, context)
+  end
+
+  def test_lsp_completion_context_trigger_character_colon
+    # Empty prefix and :: trigger
+    context = lsp_completion_context("", [":", "::", "."], ":")
+    assert_equal({ triggerKind: 2, triggerCharacter: ":" }, context)
+  end
+
+  def test_lsp_completion_context_prefix_overrides_trigger_char
+    # Even when char before start is a trigger char, prefix present → Invoked
+    context = lsp_completion_context("bo", ["."], ".")
+    assert_equal({ triggerKind: 1 }, context)
+  end
+end

--- a/test/textbringer/lsp/test_client.rb
+++ b/test/textbringer/lsp/test_client.rb
@@ -100,6 +100,7 @@ class TestLSPClient < Textbringer::TestCase
     assert(capabilities[:textDocument][:completion])
     assert(capabilities[:textDocument][:synchronization])
     refute(capabilities[:textDocument][:completion][:completionItem][:snippetSupport])
+    assert(capabilities[:textDocument][:completion][:contextSupport])
 
     # Signature help capabilities
     sig_help = capabilities[:textDocument][:signatureHelp]


### PR DESCRIPTION
Without a context, some LSP servers don't return member completions when the cursor is right after a trigger character (e.g. "window."). Now lsp_completion checks completionProvider.triggerCharacters and:
- sends triggerKind=2 + triggerCharacter when prefix is empty and the character before start_point is a trigger character (e.g. ".")
- sends triggerKind=1 (Invoked) otherwise

Using triggerKind=2 only when prefix is empty avoids returning the full unfiltered member list while the user is mid-identifier.