### PR TITLE
Respect server textDocumentSync capability for didChange notifications

### DIFF
--- a/test/textbringer/commands/test_lsp.rb
+++ b/test/textbringer/commands/test_lsp.rb
@@ -36,4 +36,35 @@ class TestLSPCommands < Textbringer::TestCase
     context = lsp_completion_context("bo", ["."], ".")
     assert_equal({ triggerKind: 1 }, context)
   end
+
+  # lsp_text_document_sync_kind
+
+  def test_sync_kind_integer_none
+    assert_equal(0, lsp_text_document_sync_kind("textDocumentSync" => 0))
+  end
+
+  def test_sync_kind_integer_full
+    assert_equal(1, lsp_text_document_sync_kind("textDocumentSync" => 1))
+  end
+
+  def test_sync_kind_integer_incremental
+    assert_equal(2, lsp_text_document_sync_kind("textDocumentSync" => 2))
+  end
+
+  def test_sync_kind_hash_full
+    assert_equal(1, lsp_text_document_sync_kind("textDocumentSync" => { "change" => 1 }))
+  end
+
+  def test_sync_kind_hash_incremental
+    assert_equal(2, lsp_text_document_sync_kind("textDocumentSync" => { "change" => 2 }))
+  end
+
+  def test_sync_kind_hash_without_change_key_defaults_to_incremental
+    # Hash present but no "change" key → default to Incremental (2)
+    assert_equal(2, lsp_text_document_sync_kind("textDocumentSync" => { "openClose" => true }))
+  end
+
+  def test_sync_kind_missing_capability_defaults_to_incremental
+    assert_equal(2, lsp_text_document_sync_kind({}))
+  end
 end


### PR DESCRIPTION
Solargraph (and other servers) advertise textDocumentSync: 1 (Full), meaning they expect the complete document text on every didChange notification rather than incremental ranges. Sending incremental changes to a Full-sync server leaves it with a stale view of the document, preventing type inference for local variables.

Now lsp_setup_buffer_hooks reads textDocumentSync from server capabilities and sends either a full document or an incremental range accordingly.