### PR TITLE
Fix SKK cursor color not reset on buffer switch or exit

### DIFF
--- a/lib/textbringer/buffer.rb
+++ b/lib/textbringer/buffer.rb
@@ -112,11 +112,13 @@ module Textbringer
     end
 
     def self.current=(buffer)
+      @@current&.input_method&.on_deactivate
       if buffer && buffer.name && @@table.key?(buffer.name)
         @@list.delete(buffer)
         @@list.unshift(buffer)
       end
       @@current = buffer
+      @@current&.input_method&.on_activate
     end
 
     def self.minibuffer

--- a/lib/textbringer/input_method.rb
+++ b/lib/textbringer/input_method.rb
@@ -36,6 +36,12 @@ module Textbringer
       @enabled = false
     end
 
+    def on_activate
+    end
+
+    def on_deactivate
+    end
+
     def enabled?
       @enabled
     end

--- a/lib/textbringer/input_methods/skk_input_method.rb
+++ b/lib/textbringer/input_methods/skk_input_method.rb
@@ -143,6 +143,14 @@ module Textbringer
       close_skk_server
     end
 
+    def on_activate
+      update_cursor_color if @enabled
+    end
+
+    def on_deactivate
+      reset_cursor_color if @enabled
+    end
+
     def status
       case @phase
       when :converting then "▽"

--- a/lib/textbringer/window.rb
+++ b/lib/textbringer/window.rb
@@ -175,6 +175,7 @@ module Textbringer
         @@started = true
         yield
       ensure
+        Buffer.current&.input_method&.on_deactivate
         @@list.each do |win|
           win.close
         end


### PR DESCRIPTION
Add on_activate/on_deactivate lifecycle hooks to InputMethod base class and override them in SkkInputMethod to update/reset the cursor color. Call these hooks in Buffer.current= when the active buffer changes, and in Window.start's ensure block to restore the cursor color on exit.