### PR TITLE
Add @@color_pair_cache to deduplicate ncurses color pair slots

### DIFF
--- a/lib/textbringer/face.rb
+++ b/lib/textbringer/face.rb
@@ -6,6 +6,7 @@ module Textbringer
 
     @@face_table = {}
     @@next_color_pair = 1
+    @@color_pair_cache = {}
 
     def self.[](name)
       @@face_table[name]
@@ -27,8 +28,6 @@ module Textbringer
 
     def initialize(name, **opts)
       @name = name
-      @color_pair = @@next_color_pair
-      @@next_color_pair += 1
       update(**opts)
     end
 
@@ -67,8 +66,15 @@ module Textbringer
       @bold = @explicit_bold.nil? ? (parent&.instance_variable_get(:@bold) || false) : @explicit_bold
       @underline = @explicit_underline.nil? ? (parent&.instance_variable_get(:@underline) || false) : @explicit_underline
       @reverse = @explicit_reverse.nil? ? (parent&.instance_variable_get(:@reverse) || false) : @explicit_reverse
-      Curses.init_pair(@color_pair,
-                       Color[@foreground], Color[@background])
+      fg_num = Color[@foreground]
+      bg_num = Color[@background]
+      key = [fg_num, bg_num]
+      unless @@color_pair_cache.key?(key)
+        @@color_pair_cache[key] = @@next_color_pair
+        Curses.init_pair(@@next_color_pair, fg_num, bg_num)
+        @@next_color_pair += 1
+      end
+      @color_pair = @@color_pair_cache[key]
       @text_attrs = 0
       @text_attrs |= Curses::A_BOLD if @bold
       @text_attrs |= Curses::A_UNDERLINE if @underline

--- a/test/textbringer/test_face.rb
+++ b/test/textbringer/test_face.rb
@@ -23,13 +23,41 @@ class TestFace < Textbringer::TestCase
   def test_inherit_colors
     parent = Face.define(:parent_face, foreground: "red", background: "blue")
     child = Face.define(:child_face, inherit: :parent_face)
-    assert_not_equal(parent.color_pair, child.color_pair)
-    # Child should inherit parent's foreground/background
+    # Child inherits same colors as parent — they share the same color pair slot
+    assert_equal(parent.color_pair, child.color_pair)
     assert_equal("red", child.instance_variable_get(:@foreground))
     assert_equal("blue", child.instance_variable_get(:@background))
   ensure
     Face.delete(:parent_face)
     Face.delete(:child_face)
+  end
+
+  def test_color_pair_cache_shared_for_same_colors
+    a = Face.define(:cache_a, foreground: "cyan", background: "magenta")
+    b = Face.define(:cache_b, foreground: "cyan", background: "magenta")
+    assert_equal(a.color_pair, b.color_pair)
+  ensure
+    Face.delete(:cache_a)
+    Face.delete(:cache_b)
+  end
+
+  def test_color_pair_cache_different_for_different_colors
+    a = Face.define(:diff_a, foreground: "cyan", background: "magenta")
+    b = Face.define(:diff_b, foreground: "yellow", background: "magenta")
+    assert_not_equal(a.color_pair, b.color_pair)
+  ensure
+    Face.delete(:diff_a)
+    Face.delete(:diff_b)
+  end
+
+  def test_color_pair_cache_no_new_slot_for_duplicate
+    Face.define(:dup_a, foreground: "white", background: "black")
+    slot_before = Face.class_variable_get(:@@next_color_pair)
+    Face.define(:dup_b, foreground: "white", background: "black")
+    assert_equal(slot_before, Face.class_variable_get(:@@next_color_pair))
+  ensure
+    Face.delete(:dup_a)
+    Face.delete(:dup_b)
   end
 
   def test_inherit_styles


### PR DESCRIPTION
Faces with identical resolved fg/bg colors now share the same color_pair number instead of each allocating a fresh slot. Curses.init_pair is called only once per unique color combination, conserving the limited pool of ncurses color pair slots (often 256).