### PR TITLE
Use orange for constants in the github theme

### DIFF
--- a/lib/textbringer/themes/github.rb
+++ b/lib/textbringer/themes/github.rb
@@ -54,7 +54,7 @@ Textbringer::Theme.define "github" do |t|
   t.face :keyword,                  foreground: :red       # Statement = red
   t.face :string,                   foreground: :darkblue  # String = darkblue
   t.face :number,                   foreground: :blue      # Number → Constant = blue
-  t.face :constant,                 foreground: :blue      # Constant = blue
+  t.face :constant,                 foreground: :orange    # Constant = orange
   t.face :function_name,            foreground: :purple    # Function = purple
   t.face :type,                     foreground: :red       # Type = red
   t.face :variable,                 foreground: :blue      # Identifier = blue


### PR DESCRIPTION
Constant names are orange at GitHub in May 2026