### PR TITLE
Cache Prism.lex tokens and reuse across highlight, in_literal?, and d…

### DIFF
--- a/lib/textbringer/modes/ruby_mode.rb
+++ b/lib/textbringer/modes/ruby_mode.rb
@@ -476,8 +476,11 @@ module Textbringer
     def ensure_prism_tokens
       return if @prism_version == @buffer.version
       source = @buffer.to_s
-      return unless source.valid_encoding?
-      @prism_tokens = Prism.lex(source).value
+      if source.valid_encoding?
+        @prism_tokens = Prism.lex(source).value
+      else
+        @prism_tokens = []
+      end
       @prism_version = @buffer.version
       @literal_levels_version = nil
     end


### PR DESCRIPTION
…efinitions

Replace per-call Prism.lex invocations with a shared @prism_tokens cache invalidated by buffer version. in_literal? now uses binary search over a precomputed literal nesting level array instead of re-lexing.