### PR TITLE
Support direct color terminals (TERM=xterm-direct)

### DIFF
--- a/lib/textbringer/color.rb
+++ b/lib/textbringer/color.rb
@@ -22,6 +22,30 @@ module Textbringer
       "brightwhite" => 15
     }
 
+    DIRECT_COLOR_THRESHOLD = 256 * 256 * 256
+
+    # Canonical RGB values for basic ANSI colors (xterm defaults),
+    # packed as 0xRRGGBB for use in direct color mode.
+    BASIC_COLORS_RGB = {
+      "default"       => -1,
+      "black"         => 0x000000,
+      "red"           => 0xCD0000,
+      "green"         => 0x00CD00,
+      "yellow"        => 0xCDCD00,
+      "blue"          => 0x0000EE,
+      "magenta"       => 0xCD00CD,
+      "cyan"          => 0x00CDCD,
+      "white"         => 0xE5E5E5,
+      "brightblack"   => 0x7F7F7F,
+      "brightred"     => 0xFF0000,
+      "brightgreen"   => 0x00FF00,
+      "brightyellow"  => 0xFFFF00,
+      "brightblue"    => 0x5C5CFF,
+      "brightmagenta" => 0xFF00FF,
+      "brightcyan"    => 0x00FFFF,
+      "brightwhite"   => 0xFFFFFF
+    }
+
     RGBColor = Struct.new(:r, :g, :b, :number)
 
     ADDITIONAL_COLORS = []
@@ -46,9 +70,16 @@ module Textbringer
       end
     end
 
+    def self.direct_color?
+      Window.colors >= DIRECT_COLOR_THRESHOLD
+    end
+
     def self.find_color_number(name)
       if name.is_a?(Integer)
         return name
+      end
+      if direct_color?
+        return find_direct_color(name)
       end
       case name
       when /\A\#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})\z/
@@ -63,6 +94,21 @@ module Textbringer
           raise EditorError, "No such color: #{name}"
         end
         BASIC_COLORS[name]
+      end
+    end
+
+    def self.find_direct_color(name)
+      case name
+      when /\A\#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})\z/
+        r = $1.to_i(16)
+        g = $2.to_i(16)
+        b = $3.to_i(16)
+        (r << 16) | (g << 8) | b
+      else
+        unless BASIC_COLORS_RGB.key?(name)
+          raise EditorError, "No such color: #{name}"
+        end
+        BASIC_COLORS_RGB[name]
       end
     end
   end

--- a/test/textbringer/test_color.rb
+++ b/test/textbringer/test_color.rb
@@ -37,4 +37,49 @@ class TestColor < Textbringer::TestCase
   ensure
     Curses.colors = 256
   end
+
+  def test_direct_color
+    Curses.colors = 16_777_216
+
+    # Hex colors should be packed as direct RGB
+    assert_equal(0xFF0000, Color["#FF0000"])
+    assert_equal(0x00FF00, Color["#00FF00"])
+    assert_equal(0x0000FF, Color["#0000FF"])
+    assert_equal(0x000000, Color["#000000"])
+    assert_equal(0xFFFFFF, Color["#FFFFFF"])
+    assert_equal(0x5F00AF, Color["#5F00AF"])
+
+    # Basic color names should map to xterm default RGB values
+    assert_equal(-1, Color["default"])
+    assert_equal(0x000000, Color["black"])
+    assert_equal(0xCD0000, Color["red"])
+    assert_equal(0x00CD00, Color["green"])
+    assert_equal(0xCDCD00, Color["yellow"])
+    assert_equal(0x0000EE, Color["blue"])
+    assert_equal(0xCD00CD, Color["magenta"])
+    assert_equal(0x00CDCD, Color["cyan"])
+    assert_equal(0xE5E5E5, Color["white"])
+    assert_equal(0xFF00FF, Color["brightmagenta"])
+    assert_equal(0xFFFFFF, Color["brightwhite"])
+
+    # Integer passthrough still works
+    assert_equal(0xFF0000, Color[0xFF0000])
+    assert_equal(0, Color[0])
+
+    assert_raise(EditorError) do
+      Color["foo"]
+    end
+  ensure
+    Curses.colors = 256
+  end
+
+  def test_direct_color_detection
+    Curses.colors = 256
+    refute Color.direct_color?
+
+    Curses.colors = 16_777_216
+    assert Color.direct_color?
+  ensure
+    Curses.colors = 256
+  end
 end

--- a/test/textbringer/test_theme.rb
+++ b/test/textbringer/test_theme.rb
@@ -68,6 +68,14 @@ class TestTheme < Textbringer::TestCase
     Curses.colors = old_colors
   end
 
+  def test_color_tier_hex_for_direct_color
+    old_colors = Curses.colors
+    Curses.colors = 16_777_216
+    assert_equal(:hex, Theme.color_tier)
+  ensure
+    Curses.colors = old_colors
+  end
+
   def test_background_mode_defaults_to_dark
     old_mode = CONFIG[:background_mode]
     CONFIG[:background_mode] = nil


### PR DESCRIPTION
In direct color mode, Curses.colors returns 16777216 and color numbers passed to init_pair are interpreted as packed RGB values (R<<16|G<<8|B), not palette indices. Convert hex colors directly to packed RGB and map ANSI color names to their xterm default RGB values in this mode.