### PR TITLE
Add forward-page and backward-page commands

### DIFF
--- a/lib/textbringer/commands/misc.rb
+++ b/lib/textbringer/commands/misc.rb
@@ -354,6 +354,36 @@ module Textbringer
       RubyVM::MJIT.resume
     end
 
+    define_command(:forward_page,
+                   doc: "Move forward to page boundary.") do
+      |n = number_prefix_arg|
+      buffer = Buffer.current
+      n.times do
+        unless buffer.re_search_forward(/^\f/, raise_error: false)
+          buffer.end_of_buffer
+          break
+        end
+      end
+    end
+
+    define_command(:backward_page,
+                   doc: "Move backward to page boundary.") do
+      |n = number_prefix_arg|
+      buffer = Buffer.current
+      n.times do
+        if buffer.point == 0
+          break
+        end
+        buffer.backward_char
+        if buffer.re_search_backward(/^\f/, raise_error: false)
+          buffer.forward_char
+        else
+          buffer.beginning_of_buffer
+          break
+        end
+      end
+    end
+
     define_command(:what_cursor_position,
                    doc: "Print info on cursor position.") do
       |arg = current_prefix_arg|

--- a/lib/textbringer/keymap.rb
+++ b/lib/textbringer/keymap.rb
@@ -167,6 +167,8 @@ module Textbringer
   GLOBAL_MAP.define_key(:npage, :scroll_up)
   GLOBAL_MAP.define_key("\M-v", :scroll_down)
   GLOBAL_MAP.define_key(:ppage, :scroll_down)
+  GLOBAL_MAP.define_key("\C-x]", :forward_page)
+  GLOBAL_MAP.define_key("\C-x[", :backward_page)
   GLOBAL_MAP.define_key("\C-x0", :delete_window)
   GLOBAL_MAP.define_key("\C-x1", :delete_other_windows)
   GLOBAL_MAP.define_key("\C-x2", :split_window)

--- a/test/textbringer/commands/test_misc.rb
+++ b/test/textbringer/commands/test_misc.rb
@@ -206,6 +206,56 @@ class TestMisc < Textbringer::TestCase
     assert_equal("Backtrace", Buffer.current.mode.name)
   end
 
+  def test_forward_page
+    insert("page1\n\fpage2\n\fpage3\n")
+    beginning_of_buffer
+    forward_page
+    assert_equal(7, Buffer.current.point)  # after first \f
+    forward_page
+    assert_equal(14, Buffer.current.point) # after second \f
+    forward_page
+    assert_equal(Buffer.current.bytesize, Buffer.current.point) # end of buffer
+  end
+
+  def test_forward_page_no_delimiter
+    insert("no page delimiter here\n")
+    beginning_of_buffer
+    forward_page
+    assert_equal(Buffer.current.bytesize, Buffer.current.point)
+  end
+
+  def test_forward_page_with_count
+    insert("page1\n\fpage2\n\fpage3\n")
+    beginning_of_buffer
+    forward_page(2)
+    assert_equal(14, Buffer.current.point) # after second \f
+  end
+
+  def test_backward_page
+    insert("page1\n\fpage2\n\fpage3\n")
+    end_of_buffer
+    backward_page
+    assert_equal(14, Buffer.current.point) # just after second \f
+    backward_page
+    assert_equal(7, Buffer.current.point)  # just after first \f
+    backward_page
+    assert_equal(0, Buffer.current.point)  # beginning of buffer
+  end
+
+  def test_backward_page_no_delimiter
+    insert("no page delimiter here\n")
+    end_of_buffer
+    backward_page
+    assert_equal(0, Buffer.current.point)
+  end
+
+  def test_backward_page_with_count
+    insert("page1\n\fpage2\n\fpage3\n")
+    end_of_buffer
+    backward_page(2)
+    assert_equal(7, Buffer.current.point)  # just after first \f
+  end
+
   def test_what_cursor_position
     insert(" \t\C-lあ")
     beginning_of_buffer


### PR DESCRIPTION
## Summary
- Add `forward_page` / `backward_page` commands, mirroring Emacs's `forward-page` / `backward-page`
- Bind `C-x ]` to `forward-page` and `C-x [` to `backward-page`
- A page boundary is any line beginning with a form feed character (`\f`), matching Emacs's default `page-delimiter` convention
- Both commands accept a numeric prefix argument to move multiple pages at once, and stop at the buffer boundary when no more page delimiters are found

## Test plan
- [x] `bundle exec rake test` passes (736 tests, 0 failures, 0 errors)
- [x] Manually verified `C-x ]` / `C-x [` navigation behavior in the editor, including that `backward-page` correctly skips the delimiter immediately behind point and lands just after the previous one, matching Emacs's behavior