### PR TITLE
Remove dependency to fiddley

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Install ncursesw before installing curses.gem, on which textbringer depends.
     $ sudo apt-get install libncursesw5-dev
     $ gem install curses
 
+You need ffi to use clipboard commands on Windows.
+
+    $ gem install ffi
+
 ## Usage
 
     $ txtb

--- a/lib/textbringer/commands/clipboard.rb
+++ b/lib/textbringer/commands/clipboard.rb
@@ -2,12 +2,15 @@ module Clipboard
   @implementation = nil
 end
 
-require "clipboard"
-
 module Textbringer
   module Commands
-    CLIPBOARD_AVAILABLE =
-      Clipboard.implementation.name != "Clipboard::File"
+    begin
+      require "clipboard"
+      CLIPBOARD_AVAILABLE =
+        Clipboard.implementation.name != "Clipboard::File"
+    rescue LoadError
+      CLIPBOARD_AVAILABLE = false
+    end
 
     if CLIPBOARD_AVAILABLE
       GLOBAL_MAP.define_key("\M-w", :clipboard_copy_region)

--- a/textbringer.gemspec
+++ b/textbringer.gemspec
@@ -30,8 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "curses", ">= 1.2.7"
   spec.add_runtime_dependency "unicode-display_width", ">= 1.1"
   spec.add_runtime_dependency "clipboard", ">= 1.1"
-  spec.add_runtime_dependency "fiddle"
-  spec.add_runtime_dependency "fiddley", ">= 0.0.5"
   spec.add_runtime_dependency "editorconfig"
   spec.add_runtime_dependency "warning"
   spec.add_runtime_dependency "unicode-name"

--- a/textbringer.gemspec
+++ b/textbringer.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "irb"
   spec.add_runtime_dependency "nkf"
   spec.add_runtime_dependency "drb"
+  spec.add_runtime_dependency "fiddle" # for reline on Windows
   spec.add_runtime_dependency "curses", ">= 1.2.7"
   spec.add_runtime_dependency "unicode-display_width", ">= 1.1"
   spec.add_runtime_dependency "clipboard", ">= 1.1"


### PR DESCRIPTION
Because clipboard-2.0.0 doesn't work with fiddley:

```
NoMethodError: undefined method 'null?' for an instance of Fiddley::MemoryPointer
C:/Ruby34-x64/lib/ruby/gems/3.4.0/gems/clipboard-2.0.0/lib/clipboard/windows.rb:58:in 'C
lipboard::Windows#paste'
```

Windows users should install ffi instead if they want clipboard commands.