### PR TITLE
Use concrete default colors for face color pairs

### DIFF
--- a/lib/textbringer/face.rb
+++ b/lib/textbringer/face.rb
@@ -7,6 +7,8 @@ module Textbringer
     @@face_table = {}
     @@next_color_pair = 1
     @@color_pair_cache = {}
+    @@default_foreground = -1
+    @@default_background = -1
 
     def self.[](name)
       @@face_table[name]
@@ -24,6 +26,20 @@ module Textbringer
 
     def self.delete(name)
       @@face_table.delete(name)
+    end
+
+    # Set the concrete color numbers substituted for -1 (default color).
+    # PDCurses resolves -1 when init_pair is called and
+    # assume_default_colors only affects color pair 0, so faces must be
+    # re-resolved with concrete colors to get the new default colors.
+    def self.set_default_color_numbers(fg_num, bg_num)
+      return if fg_num == @@default_foreground &&
+        bg_num == @@default_background
+      @@default_foreground = fg_num
+      @@default_background = bg_num
+      @@face_table.each_value do |face|
+        face.send(:resolve_inheritance)
+      end
     end
 
     def initialize(name, **opts)
@@ -68,6 +84,8 @@ module Textbringer
       @reverse = @explicit_reverse.nil? ? (parent&.instance_variable_get(:@reverse) || false) : @explicit_reverse
       fg_num = Color[@foreground]
       bg_num = Color[@background]
+      fg_num = @@default_foreground if fg_num == -1
+      bg_num = @@default_background if bg_num == -1
       key = [fg_num, bg_num]
       unless @@color_pair_cache.key?(key)
         @@color_pair_cache[key] = @@next_color_pair

--- a/lib/textbringer/window.rb
+++ b/lib/textbringer/window.rb
@@ -137,9 +137,12 @@ module Textbringer
     def self.set_default_colors(fg, bg)
       new_fg = fg || @@default_fg
       new_bg = bg || @@default_bg
-      Curses.assume_default_colors(Color[new_fg], Color[new_bg])
+      fg_num = Color[new_fg]
+      bg_num = Color[new_bg]
+      Curses.assume_default_colors(fg_num, bg_num)
       @@default_fg = new_fg
       @@default_bg = new_bg
+      Face.set_default_color_numbers(fg_num, bg_num)
       Face.define(:default, foreground: new_fg, background: new_bg)
       Window.redraw if @@started
     end

--- a/test/textbringer/test_face.rb
+++ b/test/textbringer/test_face.rb
@@ -176,6 +176,33 @@ class TestFace < Textbringer::TestCase
     Face.delete(:persist_child)
   end
 
+  def test_default_colors_substituted_for_faces
+    # PDCurses resolves -1 at init_pair time and assume_default_colors
+    # only affects color pair 0, so faces without explicit colors must
+    # use concrete default colors instead of -1.
+    Window.set_default_colors("white", "blue")
+    face = Face.define(:sub_face, foreground: "yellow")
+    explicit = Face.define(:sub_explicit,
+                           foreground: "yellow", background: "blue")
+    assert_equal(explicit.color_pair, face.color_pair)
+  ensure
+    Face.delete(:sub_face)
+    Face.delete(:sub_explicit)
+    Window.set_default_colors("default", "default")
+  end
+
+  def test_faces_reresolved_when_default_colors_change
+    face = Face.define(:re_face, foreground: "yellow")
+    Window.set_default_colors("white", "blue")
+    explicit = Face.define(:re_explicit,
+                           foreground: "yellow", background: "blue")
+    assert_equal(explicit.color_pair, face.color_pair)
+  ensure
+    Face.delete(:re_face)
+    Face.delete(:re_explicit)
+    Window.set_default_colors("default", "default")
+  end
+
   def test_parent_update_propagates_to_children
     Face.define(:prop_parent, foreground: "red")
     child = Face.define(:prop_child, inherit: :prop_parent)


### PR DESCRIPTION
## Problem

On Windows (curses gem with bundled PDCursesMod), faces without an explicit background (e.g. `keyword`) were rendered with the terminal's original background instead of the theme background.

## Cause

Textbringer initializes color pairs for such faces with `-1` (default color) and applies the theme background afterwards via `Curses.assume_default_colors`. This works with ncurses, where `-1` is kept in the pair and resolved to the assumed default colors at render time. PDCursesMod, however, resolves `-1` to the terminal's original colors at `init_pair` time (`_normalize()` in `pdcurses/color.c`), and its `assume_default_colors` re-initializes only color pair 0. As a result, only plain text (pair 0) got the theme background.

## Fix

- `Face` now keeps the concrete default color numbers and substitutes them for `-1` when initializing color pairs.
- `Window.set_default_colors` notifies `Face`, which re-resolves all faces when the default colors change.

No platform detection is needed: on ncurses the substituted colors equal the assumed defaults, so rendering is unchanged. When no theme is active (default colors are "default"), `-1` is used as before, preserving terminal default/transparent backgrounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)