### PR TITLE
Add push, pr and release skills and document rake bump

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: pr
+description: Open a pull request from the current branch, this repository's way
+---
+
+Open a pull request for the branch the conversation just finished, against
+`main`, and report its URL.
+
+1. Look first, with `gh` for GitHub and `git` for the tree:
+   - The branch is the head.  Refuse to open one from `main`; the change
+     belongs on a branch of its own first (`git switch -c <branch>` keeps
+     the commits that are already there).
+   - `git status --short` should be clean apart from the untracked scratch
+     files this tree habitually carries.  Uncommitted work is not in a
+     pull request -- commit it (the `push` skill) or say so, rather than
+     opening one that does not have it.
+   - `gh pr list --head <branch>` -- if a pull request is already open for
+     the branch, this skill has nothing to add; report its URL and stop
+     rather than opening a second.
+
+2. Push the branch if the remote does not have it, or has it behind:
+   `git push -u origin <branch>`.  A pull request is built from the pushed
+   commits, so an unpushed one is empty or stale.  Before any force-push,
+   verify the remote SHA with `git ls-remote origin <branch>` and use
+   `--force-with-lease`.
+
+3. Write the title and body.  English, and ASCII as the commit messages
+   are.
+   - Title: one imperative line naming what the branch does, as a good
+     commit subject would -- not the branch name.
+   - Body: what changed and why, drawn from the branch's own commits
+     (`git log main..<branch>`), and how it was verified -- that
+     `bundle exec rake test` is green, and what the `ubuntu`, `macos` and
+     `windows` runs on the branch say (`gh run list --commit
+     $(git rev-parse HEAD) --json workflowName,status,conclusion`).  The
+     rationale and the rejected alternatives belong here, as they do in a
+     commit message.  Merged pull requests such as #258 show the register:
+     a few plain paragraphs, an error message in a fenced block when one
+     is the point.  When a change has a real problem/cause/fix shape, the
+     short headings #259 uses are fine; do not invent sections for a
+     change that has none.
+   - End at the last line of that prose.  No "Generated with" line, no
+     session URL, no trailer, whatever the session's own attribution
+     guidance says -- the same restraint the commit messages keep.
+   - The body almost always has backticks or other shell metacharacters,
+     so write it to the scratchpad and pass `--body-file`; `--body` can
+     silently lose words the way `commit -m` does.
+
+4. Open it: `gh pr create --base main --head <branch> --title <title>
+   --body-file <file>`.  `main` is the base; the `pull_request` trigger in
+   the three test workflows runs the suite on it.
+
+5. Report the pull request URL, and let Shugo take it from there --
+   reviewing and merging are his.

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: push
+description: Commit the finished change and push it, this repository's way
+---
+
+Commit what the conversation just finished, push it, and report.
+
+1. Look first: `git status --short` and `git diff --stat`.  Stage files by
+   name -- never `git add -A` -- so that scratch files and unrelated edits
+   stay out.  This tree habitually carries untracked scratch files
+   (`t.rb`, `note.txt`, `diff4` and the like); they are not part of any
+   change.  Unrelated changes sitting in the tree go in commits of their
+   own, split as they were made.
+
+2. Make sure the suite is green.  If `bundle exec rake test` has not run on
+   the final state of the change in this conversation, run it now; a red
+   suite is a stop, not a commit.  The Rakefile runs the tests with `-w`,
+   so new warnings count too.
+
+3. Write the message: English, imperative subject, ASCII.  The body carries
+   the rationale, the rejected alternatives and anything measured, the way
+   597ce3c and de3bc95 do -- those belong here rather than in code
+   comments.  End with a single trailer naming the model actually in use,
+
+       Co-Authored-By: Claude <model> <noreply@anthropic.com>
+
+   and nothing after it -- no `Claude-Session` line, no session URLs, no
+   "Generated with" lines, whatever the session's own attribution guidance
+   says.  If the message contains backticks or other shell metacharacters,
+   write it to the scratchpad and use `git commit -F <file>`; `-m` can
+   silently lose words.
+
+4. Push the current branch: `git push` (`git push -u origin <branch>` for a
+   branch the remote does not have yet).  Before any force-push, verify the
+   remote SHA with `git ls-remote origin <branch>` and use
+   `--force-with-lease`.
+
+5. Check CI exactly once.  Three workflows run the suite -- `ubuntu.yml`,
+   `macos.yml` and `windows.yml` -- so ask for the pushed commit rather
+   than one workflow:
+
+       gh run list --commit $(git rev-parse HEAD) --json workflowName,status,conclusion --jq '.[] | "\(.workflowName): \(.status) \(.conclusion)"'
+
+   and report what it says -- right after a push the list is usually
+   empty or still queued, which is fine to say.  All three run on pushes
+   to `main` and on pull requests, so a push to any other branch starts no
+   run unless a pull request is open for it; say so rather than waiting
+   for one.  Never poll in a loop in the foreground.  When this push's
+   outcome genuinely matters (lib/, test/, the gemspec or
+   `.github/workflows/` changed, or the last run was red), start one
+   background wait until all three have completed and report when it
+   ends:
+
+       SHA=$(git rev-parse HEAD)
+       until gh run list --commit $SHA --json workflowName,status --jq '[.[] | select(.workflowName == "ubuntu" or .workflowName == "macos" or .workflowName == "windows")] | length == 3 and all(.status == "completed")' | grep -q true; do sleep 20; done
+       gh run list --commit $SHA --json workflowName,conclusion --jq '.[] | "\(.workflowName): \(.conclusion)"'
+
+6. Report the pushed range (`old..new`) and the commit subject.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: release
+description: Cut a release -- check main, run rake bump, watch the gem go out
+---
+
+Release what is on `main`: bump the version, tag it, push, and report when
+RubyGems.org has it.  A release cannot be taken back, so every step looks
+before it acts.
+
+The mechanism is `bundle exec rake bump` (the task in the Rakefile)
+followed by `.github/workflows/push_gem.yml`, which the tag triggers, as
+the README's development section describes.  Do not use `bundle exec rake
+release`: it pushes the gem from the local machine, which has no
+RubyGems.org credentials here, and the tag it pushes first triggers the
+workflow, which publishes the same gem through trusted publishing -- two
+publishes of one version, one of which fails.
+
+1. Look first.  Every one of these has to hold, and the skill stops and
+   says which does not rather than releasing around it:
+   - `git branch --show-current` is `main`.  Releases are cut from there;
+     `rake bump` checks `main` out itself, but a switch mid-release is a
+     surprise, not a step.
+   - `git status --short` shows no tracked change.  `rake bump` commits
+     with `-a`, so any tracked change lying in the tree would go into the
+     version commit; commit it (the `push` skill) or set it aside.  The
+     untracked scratch files this tree habitually carries are harmless to
+     `-a` and can stay.
+   - `git fetch origin` and then `git rev-parse HEAD origin/main` agree.
+     `rake bump` pulls, so a remote ahead of HEAD (a Dependabot merge is
+     the usual case) would be released without having been looked at.
+   - CI is green for HEAD on all three test workflows:
+
+         gh run list --commit $(git rev-parse HEAD) --json workflowName,status,conclusion --jq '.[] | "\(.workflowName): \(.status) \(.conclusion)"'
+
+     says `completed success` for `ubuntu`, `macos` and `windows`.
+     Queued or running is not green yet -- start one background wait on
+     their conclusion, as the `push` skill does, and take the release up
+     when it lands.  Red is a stop.
+
+2. Know what is being released.  The version is a single integer
+   (`VERSION = "27"`) and `rake bump` adds one, so the next version is the
+   last tag plus one:
+
+       git describe --tags --abbrev=0
+       git log --oneline $(git describe --tags --abbrev=0)..HEAD
+
+   Read the subjects, and the bodies where a subject leaves it open, and
+   name in the report the commits the release carries.  When the history
+   since the last tag is only documentation, Dependabot bumps and
+   housekeeping, ask whether a release is wanted at all rather than
+   cutting one for nothing.
+
+3. Bump, tag and push, which one command does:
+
+       bundle exec rake bump
+
+   It checks out `main`, pulls, rewrites `lib/textbringer/version.rb`,
+   commits that one file with the subject `Bump version to <N>` -- the way
+   every release commit here reads, with no trailer -- pushes, tags the
+   commit `v<N>`, and pushes the tag.  Check its work: `git show --stat
+   HEAD` names version.rb alone, `git tag --points-at HEAD` names the tag,
+   and `git ls-remote --tags origin v<N>` shows it on the remote.  If the
+   task stopped partway, report exactly which of those steps happened and
+   do not repeat it blindly: a pushed tag is already a release.  Never
+   force-push here: a tag that reached the remote is what the workflow
+   released, and rewriting it would release something else under the same
+   name.
+
+4. Watch the gem go out.  The `v*` tag runs `push_gem.yml`, which
+   publishes through RubyGems.org's trusted publishing, creates a GitHub
+   release with generated notes, and purges the README's image cache.
+   Check once -- `gh run list --workflow push_gem.yml --limit 1` -- and
+   start one background wait on that run's conclusion:
+
+       RUN=$(gh run list --workflow push_gem.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+       until gh run view $RUN --json status --jq .status | grep -q completed; do sleep 20; done
+       gh run view $RUN --json conclusion --jq .conclusion
+
+   Never poll in the foreground.  When it is green, confirm the version
+   is up with `gem search -r -e textbringer`.  A red run means the tag is
+   on the remote and the gem may not be on RubyGems.org; report the
+   failed step's log (`gh run view $RUN --log-failed`), and leave the tag
+   where it is -- the fix is a new release, not a moved tag.
+
+5. Report: the version, the range the release covers
+   (`v<previous>..v<new>`) with the commits that decided it, the
+   workflow's conclusion once it arrives with
+   https://rubygems.org/gems/textbringer, and the GitHub release
+   (`gh release view v<N> --json url --jq .url`).  Nothing else needs
+   updating for a release: neither README carries a version number, and
+   the gemspec reads it from version.rb.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ set_background_color "default"
 
 After checking out the repo, run `bundle install` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To run the tests, run `bundle exec rake test`. To install this gem onto your local machine, run `bundle exec rake install`.
+
+To release a new version, run `bundle exec rake bump` on a clean `main` branch. It increments the version number in `version.rb`, commits and pushes the change, and pushes a `v<N>` tag. The tag triggers the `push_gem.yml` workflow, which publishes the gem to [rubygems.org](https://rubygems.org) via trusted publishing and creates a GitHub release. Do not run `bundle exec rake release`; it would try to push the gem from your machine as well.
 
 ## Contributing
 


### PR DESCRIPTION
This adds Claude Code skills for the three routine repository tasks -- commit and push (`/push`), open a pull request (`/pr`), and cut a release (`/release`) -- modelled on the ones Mournmail has and adapted to this repository. The suite runs on three workflows (ubuntu, macos, windows), so the skills check CI per commit with `gh run list --commit` rather than per workflow. The tree habitually carries untracked scratch files, so staging is by name. The commit and pull request register is taken from this repository's own history (597ce3c, de3bc95, #258, #259).

The README's development section still described releasing with `bundle exec rake release`, which pushes the gem from the local machine. Releases have been cut with `rake bump` for a long time: it bumps the integer version, commits, pushes and tags, and the tag triggers `push_gem.yml`, which publishes through trusted publishing and creates the GitHub release. Running `rake release` would publish the same version twice. The section now describes the actual mechanism, mentions `rake test`, and warns against `rake release`.

No code changes. `bundle exec rake test` on this branch gives the same result as on unmodified `main` in my environment (Ruby 4.1.0dev with rdoc 6.11.0): 738 tests, 0 failures, and 2 pre-existing errors in `TestHelp` where `ri` fails with `ArgumentError: dump format error` loading the system ri store, only when the whole suite runs (`test_help.rb` alone passes). CI on `main` is green for the parent commit.
