### PR TITLE
Add sync skill

### DIFF
--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: sync
+description: Switch to main, pull, and delete the work branch once its pull request is merged
+---
+
+Bring the tree back to an up-to-date `main` after a pull request has been
+merged, and clean up the branch it came from.  Nothing here is
+destructive as long as every step looks first; a branch is deleted only
+after GitHub says its pull request is merged.
+
+1. Look first:
+   - `git branch --show-current` -- remember it; if it is not `main`, it
+     is the branch to clean up in step 3.
+   - `git status --short` shows no tracked change.  A change lying in the
+     tree would follow the switch onto `main`, or block it; commit it
+     (the `push` skill) or say so and stop.  The untracked scratch files
+     this tree habitually carries are fine to leave.
+
+2. Switch and pull, fast-forward only:
+
+       git switch main
+       git pull --ff-only
+
+   `main` is never edited locally here, so a pull that cannot
+   fast-forward means something is wrong; stop and report rather than
+   merging or rebasing.  Note the range `git pull` prints (`old..new`)
+   and read `git log --oneline old..new` -- the report names what came
+   down, usually the merge of the pull request just finished plus any
+   Dependabot merges that landed meanwhile.
+
+3. Delete the work branch, once it is known to be merged.  Ask GitHub,
+   not `git branch --merged`, since a merged pull request is the fact
+   that matters:
+
+       gh pr list --head <branch> --state merged --json number,url --jq '.[0] | "\(.number) \(.url)"'
+
+   An empty answer means no merged pull request for the branch; leave it
+   alone and say so -- it may be open, or never have had one.  When there
+   is a merged pull request:
+
+       git branch -d <branch>
+       git push origin --delete <branch>
+
+   Pull requests here are merged with a merge commit, so `-d` accepts
+   the branch; if `-d` refuses, the branch has commits the merge did not
+   carry -- report that instead of reaching for `-D`.  Check the remote
+   side first with `git ls-remote --heads origin <branch>`; GitHub may
+   already have deleted it, which is not an error.  Finish with
+   `git fetch --prune` so the stale remote-tracking ref goes too.
+
+   Only the branch the tree was on is deleted.  Other local or remote
+   branches (`feature/*`, old experiments) are not this skill's
+   business, even when their pull requests are merged, unless they are
+   named explicitly.
+
+4. Report: the branch that was left, the pulled range with the merge it
+   carries, and which of the local and remote branches were deleted.


### PR DESCRIPTION
After a pull request is merged the tree has to come back to an up-to-date `main` and the work branch has to go, which is the same few commands every time. This adds a `/sync` skill for it, alongside `/push`, `/pr` and `/release` from #261.

The skill pulls with `--ff-only`, since `main` is never edited locally, and stops rather than merging or rebasing if the pull cannot fast-forward. It deletes only the branch the tree was on, and only after `gh pr list --head <branch> --state merged` reports a merged pull request for it. A remote branch GitHub has already deleted is not an error. It refuses `-D`: pull requests here are merged with a merge commit, so `git branch -d` accepts a merged branch, and a refusal means the branch carries something the merge did not carry.

No code changes. The checks the skill runs were tried against the state after #261 was merged: the branch was reported as merged, the remote side was already gone, and `git branch --merged main` agreed. `bundle exec rake test` is unaffected by this change; the two pre-existing `TestHelp` errors in my environment are the ones described in #261.
