### PR TITLE
Keep comment leaders in fill-paragraph

### DIFF
--- a/lib/textbringer/commands/fill.rb
+++ b/lib/textbringer/commands/fill.rb
@@ -155,23 +155,18 @@ module Textbringer
 
       private
 
-      # Whether the current line is a line comment of the buffer's mode.
+      # Whether the current line is a comment line of the buffer's mode.
       # Point must be at the beginning of the line.
       def comment_line?
-        leader = fill_comment_leader
-        !leader.nil? && looking_at?(/[ \t]*#{leader}/)
-      end
-
-      def fill_comment_leader
-        comment_start = mode&.comment_start
-        comment_start && Regexp.quote(comment_start)
+        re = mode&.comment_prefix_regexp
+        !re.nil? && looking_at?(re)
       end
 
       # A line that ends the paragraph: a blank line, or, when filling a
       # comment, any line that is not a comment with something in it.
       def fill_paragraph_separator(comment)
         if comment
-          /^(?![ \t]*#{fill_comment_leader}+[ \t]*[^ \t\n])/
+          /^(?!#{mode.comment_prefix_regexp}[^ \t\n])/
         else
           /^[ \t]*$/
         end
@@ -182,7 +177,7 @@ module Textbringer
       # filling a comment.
       def fill_prefix_regexp(comment)
         if comment
-          /\A[ \t]*(?:#{fill_comment_leader}+[ \t]*)?/
+          /\A(?:#{mode.comment_prefix_regexp}|[ \t]*)/
         else
           /\A[ \t]*/
         end

--- a/lib/textbringer/commands/fill.rb
+++ b/lib/textbringer/commands/fill.rb
@@ -11,23 +11,26 @@ module Textbringer
         @prefix_width = Buffer.display_width(prefix)
         @fill_column = CONFIG[:fill_column]
         @output = +""
+        @line_start = 0
         @prev_c = nil
         @bol = column == 0
       end
 
-      def fill(str)
-        input = StringIO.new(str)
-        if @bol && (indent = str[/\A[ \t]+/])
-          @output << indent
-          @column = Buffer.display_width(indent)
+      # head is kept as it is at the start of the first line; body is the
+      # text to fill, with the prefix already removed from each line.
+      def fill(head, body)
+        if !head.empty?
+          @output << head
+          @line_start = head.size
+          @column += Buffer.display_width(head)
           @bol = false
-          input.seek(indent.bytesize)
         end
+        input = StringIO.new(body)
         while c = input.getc
           if c == "\n"
             skip_blanks(input)
             if input.eof?
-              insert_newline("")
+              insert_final_newline
             elsif @column < @fill_column
               if GRAPH.match?(@prev_c)
                 insert_space_between_words(input)
@@ -73,10 +76,11 @@ module Textbringer
       end
 
       def insert_newline_before_word
-        m = @output.match(/(?:([^\w \t\n])|(\w)[ \t]+)(\w*)\z/)
+        m = @output.match(/(?:([^\w \t\n])|(\w)[ \t]+)(\w*)\z/, @line_start)
         return if m.nil?
         word = m[3]
         @output[m.begin(0)..] = "#{m[1]}#{m[2]}\n#{@prefix}#{word}"
+        @line_start = @output.size - word.size
         @column = @prefix_width + Buffer.display_width(word)
         @bol = false
       end
@@ -85,7 +89,18 @@ module Textbringer
         return if @bol
         @output.sub!(/[ \t]+\z/, "")
         @output << "\n" << prefix
+        @line_start = @output.size
         @column = Buffer.display_width(prefix)
+        @bol = true
+      end
+
+      # The newline that ends the text is kept even on an otherwise empty
+      # line, and no prefix follows it.
+      def insert_final_newline
+        @output.sub!(/[ \t]+\z/, "")
+        @output << "\n"
+        @line_start = @output.size
+        @column = 0
         @bol = true
       end
 
@@ -103,29 +118,35 @@ module Textbringer
       def fill_region(s = Buffer.current.point, e = Buffer.current.mark)
         s, e = Buffer.region_boundaries(s, e)
         save_excursion do
-          str = substring(s, e)
           goto_char(s)
           pos = point
           beginning_of_line
           column = Buffer.display_width(substring(point, pos))
-          prefix = fill_prefix(substring(point, e))
-          replace(Filler.new(column, prefix).fill(str), start: s, end: e)
+          prefix_re = fill_prefix_regexp(comment_line?)
+          prefix = fill_prefix(substring(point, e), prefix_re)
+          lines = substring(s, e).lines
+          head = column == 0 && lines[0] ? lines[0][prefix_re] : ""
+          body = lines.each_with_index.map { |line, i|
+            i == 0 ? line[head.size..] : line.sub(prefix_re, "")
+          }.join
+          replace(Filler.new(column, prefix).fill(head, body),
+                  start: s, end: e)
         end
       end
 
       def fill_paragraph
         beginning_of_line
-        while !beginning_of_buffer? &&
-            !looking_at?(/^[ \t]*$/)
+        separator = fill_paragraph_separator(comment_line?)
+        while !beginning_of_buffer? && !looking_at?(separator)
           backward_line
         end
-        while looking_at?(/^[ \t]*$/)
+        while !end_of_buffer? && looking_at?(separator)
           forward_line
         end
         s = point
         begin
           forward_line
-        end while !end_of_buffer? && !looking_at?(/^[ \t]*$/)
+        end while !end_of_buffer? && !looking_at?(separator)
         if beginning_of_line?
           backward_char
         end
@@ -134,14 +155,48 @@ module Textbringer
 
       private
 
-      # The indentation of the second line, or of the first line when
-      # there is no second line, is the prefix of every line after the
-      # first, as with adaptive-fill-mode in Emacs.  The first line keeps
-      # its own indentation.
-      def fill_prefix(str)
+      # Whether the current line is a line comment of the buffer's mode.
+      # Point must be at the beginning of the line.
+      def comment_line?
+        leader = fill_comment_leader
+        !leader.nil? && looking_at?(/[ \t]*#{leader}/)
+      end
+
+      def fill_comment_leader
+        comment_start = mode&.comment_start
+        comment_start && Regexp.quote(comment_start)
+      end
+
+      # A line that ends the paragraph: a blank line, or, when filling a
+      # comment, any line that is not a comment with something in it.
+      def fill_paragraph_separator(comment)
+        if comment
+          /^(?![ \t]*#{fill_comment_leader}+[ \t]*[^ \t\n])/
+        else
+          /^[ \t]*$/
+        end
+      end
+
+      # What is stripped from the start of each line before filling and
+      # put back by the prefix: indentation, and the comment leader when
+      # filling a comment.
+      def fill_prefix_regexp(comment)
+        if comment
+          /\A[ \t]*(?:#{fill_comment_leader}+[ \t]*)?/
+        else
+          /\A[ \t]*/
+        end
+      end
+
+      # The prefix of the second line, or of the first line when there is
+      # no second line, is the prefix of every line after the first, as
+      # with adaptive-fill-mode in Emacs.  The first line keeps its own
+      # prefix.
+      def fill_prefix(str, prefix_re)
         first, second = str.lines
-        line = second && !second.match?(/\A[ \t]*\n?\z/) ? second : first
-        line ? line[/\A[ \t]*/] : ""
+        line = second && !second.sub(prefix_re, "").match?(/\A\n?\z/) ?
+          second : first
+        line ? line[prefix_re] : ""
       end
     end
   end

--- a/lib/textbringer/mode.rb
+++ b/lib/textbringer/mode.rb
@@ -79,10 +79,22 @@ module Textbringer
     end
 
     # The string that starts a line comment in this mode, or nil if the
-    # mode has no line comments.  Used to continue comments in
-    # indent_new_comment_line and to keep comment leaders in fill_paragraph.
+    # mode has no line comments.
     def comment_start
       nil
+    end
+
+    # A regexp matching what begins a comment line: the indentation, the
+    # comment leader, and the blanks after it.  indent_new_comment_line
+    # repeats the match on the new line, and fill_paragraph uses it to
+    # tell comment lines from code and to keep the leader on each filled
+    # line.  nil if the mode has no comment lines.  Modes whose block
+    # comments continue with a leader of their own, as C's do with " * ",
+    # override this.
+    def comment_prefix_regexp
+      if comment_start
+        /[ \t]*#{Regexp.quote(comment_start)}+[ \t]*/
+      end
     end
 
     def syntax_table

--- a/lib/textbringer/mode.rb
+++ b/lib/textbringer/mode.rb
@@ -78,6 +78,13 @@ module Textbringer
       self.class.mode_name
     end
 
+    # The string that starts a line comment in this mode, or nil if the
+    # mode has no line comments.  Used to continue comments in
+    # indent_new_comment_line and to keep comment leaders in fill_paragraph.
+    def comment_start
+      nil
+    end
+
     def syntax_table
       self.class.syntax_table
     end

--- a/lib/textbringer/modes/c_mode.rb
+++ b/lib/textbringer/modes/c_mode.rb
@@ -38,6 +38,12 @@ module Textbringer
       "//"
     end
 
+    # "//" comments, and the " * " lines of a block comment.  The "/*"
+    # and " */" lines are not matched, so they bound the paragraph.
+    def comment_prefix_regexp
+      /[ \t]*(?:\/\/+|\*+(?![*\/]))[ \t]*/
+    end
+
     def initialize(buffer)
       super(buffer)
       @buffer[:indent_level] = CONFIG[:c_indent_level]

--- a/lib/textbringer/modes/programming_mode.rb
+++ b/lib/textbringer/modes/programming_mode.rb
@@ -113,10 +113,6 @@ module Textbringer
       @buffer.insert("\n" + s)
     end
 
-    def comment_start
-      nil
-    end
-
     private
 
     def calculate_indentation

--- a/lib/textbringer/modes/programming_mode.rb
+++ b/lib/textbringer/modes/programming_mode.rb
@@ -98,13 +98,14 @@ module Textbringer
     end
 
     def indent_new_comment_line
-      if comment_start.nil?
+      re = comment_prefix_regexp
+      if re.nil?
         @buffer.newline
         return
       end
       s = @buffer.save_excursion {
         @buffer.beginning_of_line
-        if @buffer.looking_at?(/[ \t]*#{comment_start}+[ \t]*/)
+        if @buffer.looking_at?(re)
           @buffer.match_string(0)
         else
           ""

--- a/test/textbringer/commands/test_fill.rb
+++ b/test/textbringer/commands/test_fill.rb
@@ -212,4 +212,104 @@ EOF
   foo bar baz
 EOF
   end
+
+  def test_fill_paragraph_ruby_comment
+    buffer.apply_mode(RubyMode)
+    buffer.insert(<<EOF)
+def foo
+  # Textbringer is beta software, and you may lose your text.  Unsaved buffers will be dumped in ~/.textbringer/buffer_dump on crash.
+  # APIs are undocumented and unstable.
+  bar
+end
+EOF
+    buffer.beginning_of_buffer
+    buffer.forward_line(2)
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+def foo
+  # Textbringer is beta software, and you may lose your text.  Unsaved
+  # buffers will be dumped in ~/.textbringer/buffer_dump on crash. APIs
+  # are undocumented and unstable.
+  bar
+end
+EOF
+  end
+
+  def test_fill_paragraph_ruby_comment_separated_by_empty_comment
+    buffer.apply_mode(RubyMode)
+    buffer.insert(<<EOF)
+# Textbringer
+#
+# Textbringer is beta software, and you may lose your text.  Unsaved buffers will be dumped in ~/.textbringer/buffer_dump on crash.
+# APIs are undocumented and unstable.
+#
+# There is no compatibility even in the same minor versions.
+EOF
+    buffer.beginning_of_buffer
+    buffer.forward_line(3)
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+# Textbringer
+#
+# Textbringer is beta software, and you may lose your text.  Unsaved
+# buffers will be dumped in ~/.textbringer/buffer_dump on crash. APIs
+# are undocumented and unstable.
+#
+# There is no compatibility even in the same minor versions.
+EOF
+  end
+
+  def test_fill_paragraph_c_comment
+    buffer.apply_mode(CMode)
+    buffer.insert(<<EOF)
+int x;
+// Textbringer is beta software, and you may lose your text.  Unsaved buffers will be dumped in ~/.textbringer/buffer_dump on crash.
+// APIs are undocumented and unstable.
+int y;
+EOF
+    buffer.beginning_of_buffer
+    buffer.forward_line(1)
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+int x;
+// Textbringer is beta software, and you may lose your text.  Unsaved
+// buffers will be dumped in ~/.textbringer/buffer_dump on crash. APIs
+// are undocumented and unstable.
+int y;
+EOF
+  end
+
+  def test_fill_paragraph_code_line_in_ruby_mode
+    buffer.apply_mode(RubyMode)
+    buffer.insert(<<EOF)
+  x = 1 # trailing comment
+  y = 2
+EOF
+    buffer.beginning_of_buffer
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+  x = 1 # trailing comment y = 2
+EOF
+  end
+
+  def test_fill_paragraph_hash_in_fundamental_mode
+    buffer.insert(<<EOF)
+# Textbringer is beta software, and you may lose your text.  Unsaved buffers will be dumped in ~/.textbringer/buffer_dump on crash.
+# APIs are undocumented and unstable.
+EOF
+    buffer.beginning_of_buffer
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+# Textbringer is beta software, and you may lose your text.  Unsaved
+buffers will be dumped in ~/.textbringer/buffer_dump on crash. # APIs
+are undocumented and unstable.
+EOF
+  end
+
+  def test_fill_paragraph_on_trailing_empty_line
+    buffer.insert("foo\n\n")
+    buffer.end_of_buffer
+    fill_paragraph
+    assert_equal("foo\n\n", buffer.to_s)
+  end
 end

--- a/test/textbringer/commands/test_fill.rb
+++ b/test/textbringer/commands/test_fill.rb
@@ -312,4 +312,72 @@ EOF
     fill_paragraph
     assert_equal("foo\n\n", buffer.to_s)
   end
+
+  def test_fill_paragraph_c_block_comment
+    buffer.apply_mode(CMode)
+    buffer.insert(<<EOF)
+/*
+ * Textbringer is beta software, and you may lose your text.  Unsaved buffers will be dumped in ~/.textbringer/buffer_dump on crash.
+ * APIs are undocumented and unstable.
+ */
+int x;
+EOF
+    buffer.beginning_of_buffer
+    buffer.forward_line(1)
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+/*
+ * Textbringer is beta software, and you may lose your text.  Unsaved
+ * buffers will be dumped in ~/.textbringer/buffer_dump on crash. APIs
+ * are undocumented and unstable.
+ */
+int x;
+EOF
+  end
+
+  def test_fill_paragraph_c_block_comment_single_line
+    buffer.apply_mode(CMode)
+    buffer.insert(<<EOF)
+/* 
+ * foo bar foo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo bar
+ */
+EOF
+    buffer.beginning_of_buffer
+    buffer.forward_line(1)
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+/* 
+ * foo bar foo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo
+ * barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo
+ * barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo
+ * barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo
+ * barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo barfoo
+ * barfoo barfoo barfoo barfoo barfoo bar
+ */
+EOF
+  end
+
+  def test_fill_paragraph_c_block_comment_separated_by_empty_line
+    buffer.apply_mode(CMode)
+    buffer.insert(<<EOF)
+/**
+ * Textbringer
+ *
+ * Textbringer is beta software, and you may lose your text.  Unsaved buffers will be dumped in ~/.textbringer/buffer_dump on crash.
+ * APIs are undocumented and unstable.
+ **/
+EOF
+    buffer.beginning_of_buffer
+    buffer.forward_line(3)
+    fill_paragraph
+    assert_equal(<<EOF, buffer.to_s)
+/**
+ * Textbringer
+ *
+ * Textbringer is beta software, and you may lose your text.  Unsaved
+ * buffers will be dumped in ~/.textbringer/buffer_dump on crash. APIs
+ * are undocumented and unstable.
+ **/
+EOF
+  end
 end

--- a/test/textbringer/modes/test_c_mode.rb
+++ b/test/textbringer/modes/test_c_mode.rb
@@ -468,4 +468,21 @@ EOF
   def test_default_compile_command
     assert_equal("make", @c_mode.default_compile_command)
   end
+
+  def test_indent_new_comment_line
+    @buffer.insert(<<EOF.chop)
+  // foo
+EOF
+    @c_mode.indent_new_comment_line
+    assert_equal("  // foo\n  // ", @buffer.to_s)
+  end
+
+  def test_indent_new_comment_line_block_comment
+    @buffer.insert(<<EOF.chop)
+/*
+ * foo
+EOF
+    @c_mode.indent_new_comment_line
+    assert_equal("/*\n * foo\n * ", @buffer.to_s)
+  end
 end


### PR DESCRIPTION
## Problem

`fill-paragraph` on a line comment lost the comment leader of every line after the first, and, since only a blank line ended a paragraph, pulled the code that followed the comment into it:

```ruby
def foo
  # Textbringer is beta software, and you may lose your text.  Unsaved buffers will be dumped in ~/.textbringer/buffer_dump on crash.
  # APIs are undocumented and unstable.
  bar
end
```

filled from the comment came out as one joined line with `bar` and `end` in it.

## Fix

Ask the buffer's mode what starts a line comment. `comment_start` already exists on `RubyMode` (`#`) and `CMode` (`//`) for `indent_new_comment_line`; its nil default moves from `ProgrammingMode` up to `Mode` so that every mode answers, and modes without line comments keep treating `#` as text.

When the line at point is a comment, the paragraph is the run of comment lines with something after the leader, so a code line or a bare `#` ends it. The prefix stripped from each line and put back after each break is the indentation plus the leader, chosen adaptively from the second line as the indentation already was in #263. A code line at point is filled as before, trailing comments included.

While there, `fill-paragraph` no longer loops forever on a blank line at the end of the buffer, where `forward_line` could not advance past the separator, and a region that is only a newline keeps that newline instead of being deleted. Line breaks are searched only after the current line's prefix, so a leader such as `#` cannot be mistaken for a break point when the first word is too long.

A comment leader is not always the string that starts a comment, so the second commit lets the mode describe the whole line prefix instead: `Mode` gains `comment_prefix_regexp`, matching the indentation, the leader and the blanks after it, built from `comment_start` by default. `CMode` overrides it to match `//` and the `*` of a continuation line of a block comment, but not `/*` or `*/`, so the opening and closing lines bound the paragraph and ` * ` is what the filled lines get. Bare `*` lines separate paragraphs the way bare `#` lines do in Ruby. `indent_new_comment_line` uses the same regexp; its own test was the default regexp already, so `#` and `//` behave as before, and M-j on a ` * ` line now continues it.

Text on the `/*` line itself is not handled; that line is not a comment line to the regexp, so a paragraph starting there is filled as code.

## Verification

Nine tests are added to `test/textbringer/commands/test_fill.rb`: a Ruby comment inside a method, Ruby comment paragraphs separated by a bare `#`, a C `//` comment, a code line in Ruby mode, `#` in fundamental mode, `fill-paragraph` on a trailing blank line, and three C block comments (a plain one, a single long line, and a `/** **/` one with a bare `*` separator). Two tests for `indent_new_comment_line` on `//` and ` * ` lines are added to `test/textbringer/modes/test_c_mode.rb`. `bundle exec rake test` gives 755 tests, 0 failures; the 2 errors in `TestHelp` are the pre-existing `ri` store errors of my environment described in #261 and are unrelated.
